### PR TITLE
Add Docker support with docker-compose for easy deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.gitmodules
+.DS_Store
+.lamprunner
+.lamprunner.data
+docs/
+*.md
+swete-admin/templates_c/
+swete-admin/livecache/
+swete-admin/snapshots/
+swete-admin/conf.db.ini.php
+swete-admin/conf.db.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM php:7.4-apache
+
+# Install PHP extensions and utilities
+RUN apt-get update && apt-get install -y \
+    unzip \
+    curl \
+    git \
+    libzip-dev \
+    && docker-php-ext-install mysqli pdo pdo_mysql zip \
+    && a2enmod rewrite \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set PHP configuration
+RUN echo "memory_limit = 2048M" > /usr/local/etc/php/conf.d/swete.ini \
+    && echo "upload_max_filesize = 64M" >> /usr/local/etc/php/conf.d/swete.ini \
+    && echo "post_max_size = 64M" >> /usr/local/etc/php/conf.d/swete.ini
+
+# Allow .htaccess overrides
+RUN sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
+
+WORKDIR /var/www/html
+
+# Copy application source
+COPY . .
+
+# Create writable directories
+RUN mkdir -p swete-admin/templates_c swete-admin/livecache swete-admin/snapshots \
+    && chown -R www-data:www-data swete-admin/templates_c swete-admin/livecache swete-admin/snapshots
+
+# Download dependencies (Xataface, SweteApp, modules)
+RUN cd bin && bash setup.sh
+
+# Copy entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 80
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -6,16 +6,54 @@ SWeTE (Simple Website Translation Engine) is an open source translation proxy wr
 * [Introductory Tutorial](docs/phparch_article/page.markdown) - (An article originally published in PHP Architect)
 * [Users Guide](https://shannah.github.com/swete)
 
+## Quick Start (Docker)
+
+The easiest way to run SWeTE is with Docker:
+
+```bash
+git clone https://github.com/shannah/swete.git
+cd swete
+docker compose up
+```
+
+Then open http://localhost:8080/swete-admin/ in your browser.
+
+To use a different port:
+
+```bash
+SWETE_PORT=9090 docker compose up
+```
+
+To run multiple instances on the same machine, use different ports and project names:
+
+```bash
+SWETE_PORT=8080 docker compose -p swete1 up
+SWETE_PORT=9090 docker compose -p swete2 up
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SWETE_PORT` | `8080` | Host port for the web interface |
+| `DB_HOST` | `db` | MySQL/MariaDB hostname |
+| `DB_NAME` | `swete` | Database name |
+| `DB_USER` | `swete` | Database user |
+| `DB_PASSWORD` | `swete` | Database password |
+
+## Manual Installation
+
+### Requirements
+
+* PHP 7.0+
+* MySQL 5+ or MariaDB 10+
+* Apache 1.3+ with mod_rewrite
+
+See the [Users Guide](https://shannah.github.com/swete) for manual installation instructions.
+
 ## License
 
 GPLv2
-
-## Requirements
-
-* PHP 5.3+
-* MySQL 5+
-* Apache 1.3+ with mod_rewrite installed
-
 
 ## Credits
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   app:
     build: .
     ports:
-      - "8080:80"
+      - "${SWETE_PORT:-8080}:80"
     environment:
       DB_HOST: db
       DB_NAME: swete

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     restart: unless-stopped
 
   db:
-    image: mysql:5.7
+    image: mysql:8.0
     environment:
       MYSQL_DATABASE: swete
       MYSQL_USER: swete

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     volumes:
       - db_data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,15 +14,12 @@ services:
     restart: unless-stopped
 
   db:
-    image: mysql:8.0
-    command: >
-      --default-authentication-plugin=mysql_native_password
-      --sql-mode=""
+    image: mariadb:10.5
     environment:
-      MYSQL_DATABASE: swete
-      MYSQL_USER: swete
-      MYSQL_PASSWORD: swete
-      MYSQL_ROOT_PASSWORD: rootpassword
+      MARIADB_DATABASE: swete
+      MARIADB_USER: swete
+      MARIADB_PASSWORD: swete
+      MARIADB_ROOT_PASSWORD: rootpassword
     volumes:
       - db_data:/var/lib/mysql
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
 
   db:
     image: mysql:8.0
+    command: >
+      --default-authentication-plugin=mysql_native_password
+      --sql-mode=NO_ENGINE_SUBSTITUTION
     environment:
       MYSQL_DATABASE: swete
       MYSQL_USER: swete

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8080:80"
+    environment:
+      DB_HOST: db
+      DB_NAME: swete
+      DB_USER: swete
+      DB_PASSWORD: swete
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  db:
+    image: mysql:5.7
+    environment:
+      MYSQL_DATABASE: swete
+      MYSQL_USER: swete
+      MYSQL_PASSWORD: swete
+      MYSQL_ROOT_PASSWORD: rootpassword
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     image: mysql:8.0
     command: >
       --default-authentication-plugin=mysql_native_password
-      --sql-mode=NO_ENGINE_SUBSTITUTION
+      --sql-mode=""
     environment:
       MYSQL_DATABASE: swete
       MYSQL_USER: swete

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+# Generate database config from environment variables
+DB_HOST="${DB_HOST:-db}"
+DB_NAME="${DB_NAME:-swete}"
+DB_USER="${DB_USER:-swete}"
+DB_PASSWORD="${DB_PASSWORD:-swete}"
+
+cat > /var/www/html/swete-admin/conf.db.ini.php <<CONF
+;<?php exit;?>
+[_database]
+	host="${DB_HOST}"
+	name="${DB_NAME}"
+	user="${DB_USER}"
+	password="${DB_PASSWORD}"
+	driver="mysqli"
+CONF
+
+# Ensure writable directories exist with correct permissions
+mkdir -p /var/www/html/swete-admin/templates_c \
+         /var/www/html/swete-admin/livecache \
+         /var/www/html/swete-admin/snapshots
+chown -R www-data:www-data /var/www/html/swete-admin/templates_c \
+                           /var/www/html/swete-admin/livecache \
+                           /var/www/html/swete-admin/snapshots
+
+# Wait for database to be ready
+echo "Waiting for database at ${DB_HOST}..."
+until php -r "new mysqli('${DB_HOST}', '${DB_USER}', '${DB_PASSWORD}', '${DB_NAME}');" 2>/dev/null; do
+    sleep 2
+done
+echo "Database is ready."
+
+exec "$@"


### PR DESCRIPTION
## Summary
This PR adds comprehensive Docker support to SWeTE, enabling users to quickly deploy the application using Docker and Docker Compose without manual installation steps.

## Key Changes
- **Dockerfile**: Created a production-ready Docker image based on PHP 7.4-Apache with all required extensions (mysqli, PDO, zip) and Apache mod_rewrite enabled
- **docker-compose.yml**: Added orchestration for multi-container setup with SWeTE app and MariaDB database services, including health checks and automatic restart policies
- **docker-entrypoint.sh**: Implemented startup script that:
  - Generates database configuration from environment variables
  - Ensures proper directory permissions for writable paths
  - Waits for database availability before starting the application
- **.dockerignore**: Added to exclude unnecessary files from Docker build context
- **README.md**: Updated with:
  - Quick Start section with Docker instructions
  - Environment variables documentation table
  - Reorganized manual installation section
  - Updated PHP requirement from 5.3+ to 7.0+
  - Added MariaDB as supported database option

## Notable Implementation Details
- Environment variables (`SWETE_PORT`, `DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`) allow flexible configuration
- Support for running multiple SWeTE instances on the same machine using different ports and project names
- Database health checks ensure the app only starts after MariaDB is ready
- Proper file permissions set for Apache-writable directories (templates_c, livecache, snapshots)
- PHP configuration optimized for file uploads (64MB limit) and memory usage (2GB limit)

https://claude.ai/code/session_011SZFrtBD2uQp94i1dE9fxH